### PR TITLE
Style in referencing 'getConfigProvider' corrected, character case changed, wrong referencing <<a487> corrected

### DIFF
--- a/tck/old-tck/source/bin/xml/impl/glassfish/config.vi.xml
+++ b/tck/old-tck/source/bin/xml/impl/glassfish/config.vi.xml
@@ -115,17 +115,6 @@
        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/glassfish" target="disable.tssv"/>
    </target>
 
-    <!-- JASPIC Configuration. -->
-    <target name="enable.jaspic">
-        <antcall target="config.jaspic"/> <!-- From s1as.xml -->
-        <antcall target="enable.tssv"/> <!-- From s1as.xml -->
-        <antcall target="config.acc.template"/>
-    </target>
-
-    <target name="disable.jaspic">
-        <antcall target="disable.tssv"/> <!-- From s1as.xml -->
-    	<antcall target="unconfig.jaspic"/> <!-- From s1as.xml -->
-    </target>
 
    <!--  Target to shutdown the Jakarta EE app server under test -->
    <target name="stop.vi" depends="checkCTSConfiguration">

--- a/tck/old-tck/source/install/jaspic/bin/build.xml
+++ b/tck/old-tck/source/install/jaspic/bin/build.xml
@@ -51,7 +51,7 @@
     <target name="runclient" 
             depends="init, set.keywords, prepare.work.report.dirs, check.selected.test, 
                      no.selected.test, check.java.options, no.java.options, translatepath">
-        <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.ri}" target="config.acc.template"/>
+        <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="config.acc.template"/>
         <ts.javatest.batch/>
     </target>
 
@@ -258,12 +258,14 @@
         <record name="config_vi.log" action="start"/>
         <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="config.vi"/>
         <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="vi.perms"/>
+        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/${impl.vi}" target="config.jaspic"/>
         <record name="config_vi.log" action="stop"/>
     </target>
 
 
     <target name="unconfig.vi">
         <record name="unconfig_vi.log" action="start"/>
+        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/${impl.vi}" target="unconfig.jaspic"/>
         <record name="unconfig_vi.log" action="stop"/>
     </target>
 
@@ -273,17 +275,35 @@
     </target>
 
 
+    <!-- Enable the use of jaspic for the app server under test -->
+    <target name="enable.tssv">
+        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/${impl.vi}" target="enable.tssv"/>
+
+        <!-- configure the sun-acc.xml template file so we can run jaspic tests in acc -->
+        <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="config.acc.template"/>
+    </target>
+
+
     <!-- convenience target.  -->
     <!-- Enables the use of jaspic for the app server under test -->
     <target name="enable.jaspic">
-        <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="enable.jaspic"/>
+        <antcall target="enable.tssv"/>
     </target>
+
+
+    <!-- Disable the use of jaspic for the app server under test -->
+    <target name="disable.tssv">
+        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/${impl.vi}" target="disable.tssv"/>
+    </target>
+
 
     <!-- convenience target.  -->
     <!-- Disables the use of jaspic for the app server under test -->
     <target name="disable.jaspic">
-        <ant antfile="config.vi.xml" dir="${bin.dir}/xml/impl/${impl.vi}" target="disable.jaspic"/>
+        <antcall target="disable.tssv"/>
     </target>
+
+
 
     <!-- ts specific jar (in this case jaspic.jar) will be created in ts.home/lib. -->
 

--- a/tck/old-tck/source/install/jaspic/bin/ts.jte
+++ b/tck/old-tck/source/install/jaspic/bin/ts.jte
@@ -520,7 +520,6 @@ impl.vi=glassfish
 impl.vi.deploy.dir=${s1as.domain}/autodeploy
 impl.deploy.timeout.multiplier=1200
 
-impl.ri=glassfish
 
 #########################################################################
 # @wsdlRepository1 Location to publish final wsdl files when using

--- a/tck/old-tck/source/install/jaspic/bin/xml/impl/glassfish/config.vi.xml
+++ b/tck/old-tck/source/install/jaspic/bin/xml/impl/glassfish/config.vi.xml
@@ -115,17 +115,6 @@
        <ant antfile="s1as.xml" dir="${common.bin.dir}/xml/impl/glassfish" target="disable.tssv"/>
    </target>
 
-    <!-- JASPIC Configuration. -->
-    <target name="enable.jaspic">
-        <antcall target="config.jaspic"/> <!-- From s1as.xml -->
-        <antcall target="enable.tssv"/> <!-- From s1as.xml -->
-        <antcall target="config.acc.template"/>
-    </target>
-
-    <target name="disable.jaspic">
-        <antcall target="disable.tssv"/> <!-- From s1as.xml -->
-    	<antcall target="unconfig.jaspic"/> <!-- From s1as.xml -->
-    </target>
 
    <!--  Target to shutdown the Jakarta EE app server under test -->
    <target name="stop.vi" depends="checkCTSConfiguration">


### PR DESCRIPTION
Hello,

the first commit with small improvements. Other commits follow.

Before commit I've generated modified Specification and verivied that all is OK.

Thank you,
Dmitri


Signed-off-by: Dmitri Cherkas <dmitricerkas@yahoo.com>