### PR TITLE
Make SOAP SPI Tests Optional

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -118,6 +118,7 @@
         <skipCDI>false</skipCDI>
         <skipJSF>false</skipJSF>
         <skipJACC>false</skipJACC>
+        <skipSOAP>false</skipSOAP>
 
         <resultlistener.home>${maven.multiModuleProjectDirectory}/target</resultlistener.home>
         <maven.test.skip>false</maven.test.skip>
@@ -667,6 +668,7 @@
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
+                <skipSOAP>true</skipSOAP>
             </properties>
 
             <dependencies>
@@ -702,6 +704,7 @@
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
+                <skipSOAP>true</skipSOAP>
             </properties>
 
             <repositories>
@@ -813,6 +816,7 @@
                 <skipCDI>true</skipCDI>
                 <skipJSF>true</skipJSF>
                 <skipJACC>true</skipJACC>
+                <skipSOAP>true</skipSOAP>
 
                 <maven.test.skip>true</maven.test.skip>
                 <skipTests>true</skipTests>

--- a/tck/spi/soap/pom.xml
+++ b/tck/spi/soap/pom.xml
@@ -108,6 +108,14 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipSOAP}</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Simple fix to make SOAP SPI tests optional in response to TCK challenge https://github.com/jakartaee/authentication/issues/215

The SOAP pom will still go through the motions of code gen and building the app, but will just skip over executing the tests if the property is set.