### PR TITLE
Fix maven-compiler-plugin version inconsistency

### DIFF
--- a/tck/common/pom.xml
+++ b/tck/common/pom.xml
@@ -21,6 +21,12 @@
     -->
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.eclipse.ee4j.tck.authentication</groupId>
+        <artifactId>jakarta-authentication-tck</artifactId>
+        <version>3.1.0-SNAPSHOT</version>
+    </parent>
+
     <groupId>org.jakartaee</groupId>
     <artifactId>jaspic-common</artifactId>
     <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
Update for TCK issue https://github.com/jakartaee/authentication/issues/214.

This allows people using version 3.8.x (where x >= 6) of Maven to run the TCK without error.