### PR TITLE
skip soap by default

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -118,7 +118,7 @@
         <skipCDI>false</skipCDI>
         <skipJSF>false</skipJSF>
         <skipJACC>false</skipJACC>
-        <skipSOAP>false</skipSOAP>
+        <skipSOAP>true</skipSOAP>
 
         <resultlistener.home>${maven.multiModuleProjectDirectory}/target</resultlistener.home>
         <maven.test.skip>false</maven.test.skip>


### PR DESCRIPTION
Continuation of #215

SOAP is always optional for this version of the spec, so we should exclude it for everyone by default. Vendors who still want to test SOAP have to enable it again themselves.